### PR TITLE
Update Create-UCSTechSupport.ps1

### DIFF
--- a/Create-UCSTechSupport.ps1
+++ b/Create-UCSTechSupport.ps1
@@ -5,16 +5,40 @@
 #Define Variables
 $cred = Get-Credential
 $domains = "ucs01.lab.local","ucs02.lab.local"
-$fileloc = "C:\Users\david\desktop\logs\"
+$filelocRoot = "C:\temp\ucs-logs\"
 
 #Cycles through each UCS creating a tech support for each chassis.
 Foreach ($ucs in $domains) {
-Connect-UCS $ucs -Credential $cred
-$Chassis = Get-UCSChassis
-  Foreach ($chassis in $chassis) {
-    $id = $chassis.id
-    $filename = "$fileloc$ucs-techsupp-chassis-$id.tar"
-    Get-UcsTechSupport -PathPattern $filename -RemoveFromUcs -TimeoutSec 600 -ChassisId $id -CIMC 'all'
-  }
-Disconnect-UCS
+
+        #Connect to UCS
+        Connect-UCS $ucs -Credential $cred
+
+        #Create the Folder for each ucs if it does not already exist
+        $fileloc = $filelocRoot + $ucs + "\"
+        if (!(Test-path $fileloc)){
+            New-Item -Path $fileloc -ItemType "directory"
+        }
+
+        #Read FI Information and export it into a Text file for Serial Number infos to have it at hand for creating a Cisco Support Case
+        $filename = $fileloc + "FIinfos.txt"
+        Get-UcsNetworkElement | select ucs, dn, vendor, model ,serial, oobifip, operability | Out-File -FilePath $filename
+
+        #Creates the UCS Manager tech support bundle and downloads it
+        $filename = $fileloc + $ucs + "-techsupp-ucsm.tar"
+        Get-UcsTechSupport -PathPattern $filename –UcsManager -RemoveFromUcs -TimeoutSec 600
+
+        #Download Chassis Tech Support Bundle for each Chassis
+        $Chassis = Get-UCSChassis
+          Foreach ($chassis in $chassis) {
+                  $id = $chassis.id
+                  $filename = $fileloc + $ucs + "-techsupp-chassis-" + $id + ".tar"
+
+                  #Abort if the file already exists
+                  if (Test-Path $filename){
+                      write-host "Bundle already exisis in folder $fileloc has to be deleted first"
+                      exit
+                  }
+                  Get-UcsTechSupport -PathPattern $filename -RemoveFromUcs -TimeoutSec 600 -ChassisId $id -CIMC 'all'
+          }
+        Disconnect-UCS
 }


### PR DESCRIPTION
Hi David,
I was verry lucky to find your code last week as I always find it annoying to download all the bundles for the ucs manager and also for all the chassis one by one if I have to open a service request at cisco for lets say the next firmware update. I added some small things which are making it for me very useful and i wanted to share this with you. Maybe it helps you too, if it does not work or you find it annoying feel free to ignore my input :-). The Idea was that i can start the script and it downloads me all the chassis files and also the ucsm file to a specific folder on the local machine together with a text file which contains the information of the UCS Domain (FI- Serial number) which i usually use to create a tech support file. So that i can run the script and afterwards have all the tech support files and also the FI Serial at hand to open a service request. It worked in our environment so i think it is adaptable. Maybe you can come up with a better idea regarding the "overwriting the files if they already exist" method as i did not spent a lot of effort there.

Let me know what u think.

All the Best
Stephan